### PR TITLE
Ensure demux completes before other prepares

### DIFF
--- a/lzplayer_core/src/main/cpp/core/VEPlayer.cpp
+++ b/lzplayer_core/src/main/cpp/core/VEPlayer.cpp
@@ -113,6 +113,7 @@ namespace VE {
             }
             case kWhatDemuxEvent: {
                 ALOGI("VEPlayer::onMessageReceived - kWhatDemuxEvent received");
+                onDemuxEvent(msg);
                 break;
             }
             case kWhatVideoDecEvent: {
@@ -212,72 +213,31 @@ namespace VE {
 
     VEResult VEPlayer::onPrepare(std::shared_ptr<AMessage> msg) {
         ALOGI("VEPlayer::%s enter", __FUNCTION__);
-        if (mDemux->open(mPath) != VE_OK) {
-            //notify error
-            onErrorCallback(VE_PLAYER_ERROR_OPEN_DEMUX_FAILED, "demux open failed!!");
+        
+        // 异步打开demux，完成后再初始化其他组件
+        std::shared_ptr<AMessage> demuxOpenMsg = std::make_shared<AMessage>(kWhatDemuxEvent, shared_from_this());
+        demuxOpenMsg->setString("action", "open");
+        demuxOpenMsg->setString("path", mPath);
+        
+        // 使用postAndAwaitResponse确保demux open完成后再继续
+        std::shared_ptr<AMessage> response;
+        demuxOpenMsg->postAndAwaitResponse(&response);
+        
+        int32_t demuxResult = VE_UNKNOWN_ERROR;
+        if (response && response->findInt32("result", &demuxResult) && demuxResult == VE_OK) {
+            // demux打开成功，继续初始化其他组件
+            onPrepareComponents();
+        } else {
+            // demux打开失败
+            ALOGE("VEPlayer::%s demux open failed", __FUNCTION__);
+            if (onErrorCallback) {
+                onErrorCallback(VE_PLAYER_ERROR_OPEN_DEMUX_FAILED, "demux open failed!!");
+            }
+            return VE_PLAYER_ERROR_OPEN_DEMUX_FAILED;
         }
 
-        mMediaInfo = mDemux->getFileInfo();
-        mAVSync = std::make_shared<VEAVsync>();
-
-        mRenderNotifyMsg = std::make_shared<AMessage>(kWhatRenderEvent, shared_from_this());
-
-        if(mMediaInfo->audio_stream_index != -1) {
-            mAudioDecodeLooper = std::make_shared<ALooper>();
-            mAudioDecodeLooper->setName("adec_thread");
-            mAudioDecodeLooper->start(false);
-
-            mAudioDecoder = std::make_shared<VEAudioDecoder>();
-            mAudioDecodeLooper->registerHandler(mAudioDecoder);
-            mAudioDecoder->prepare(mDemux);
-
-            mAudioOutputLooper = std::make_shared<ALooper>();
-            mAudioOutputLooper->setName("audio_render");
-            mAudioOutputLooper->start(false);
-
-            mAudioOutput = std::make_shared<VEAudioRender>(mRenderNotifyMsg, mAVSync);
-            mAudioOutputLooper->registerHandler(mAudioOutput);
-            VEBundle params;
-            params.set("samplerate",44100);
-            params.set("channel",2);
-            params.set("format",1);
-            params.set("decode",mAudioDecoder);
-            mAudioOutput->prepare(params);
-        }
-
-        if(mMediaInfo->video_stream_index != -1) {
-            mVideoDecodeLooper = std::make_shared<ALooper>();
-            mVideoDecodeLooper->setName("vdec_thread");
-            mVideoDecodeLooper->start(false);
-
-            mVideoDecoder = std::make_shared<VEVideoDecoder>();
-            mVideoDecodeLooper->registerHandler(mVideoDecoder);
-            mVideoDecoder->prepare(mDemux);
-
-            mVideoRenderLooper = std::make_shared<ALooper>();
-            mVideoRenderLooper->setName("video_render");
-            mVideoRenderLooper->start(false);
-            mVideoRender = std::make_shared<VEVideoDisplay>(mRenderNotifyMsg, mAVSync);
-            mVideoRenderLooper->registerHandler(mVideoRender);
-
-//            mVideoRender->prepare(mVideoDecoder, mWindow, mViewWidth, mViewHeight, mMediaInfo->fps);
-
-            VEBundle params;
-            params.set("surface",mWindow);
-            params.set("width",mViewWidth);
-            params.set("height",mViewHeight);
-            params.set("fps",mMediaInfo->fps);
-            params.set("decoder",mVideoDecoder);
-            mVideoRender->prepare(params);
-            // 如果Surface已经设置，则在初始化后调用setSurface
-//            if (mWindow != nullptr) {
-//                mVideoRender->setSurface(mWindow, mViewWidth, mViewHeight);
-//            }
-        }
-
-        onPreparedCallback();
         ALOGI("VEPlayer::%s exit", __FUNCTION__);
-        return 0;
+        return VE_OK;
     }
 
     VEResult VEPlayer::onStart(std::shared_ptr<AMessage> msg) {
@@ -492,5 +452,109 @@ namespace VE {
 
         ALOGI("VEPlayer::%s exit", __FUNCTION__);
         return 0;
+    }
+
+    VEResult VEPlayer::onDemuxEvent(std::shared_ptr<AMessage> msg) {
+        ALOGI("VEPlayer::%s enter", __FUNCTION__);
+        
+        std::string action;
+        if (!msg->findString("action", action)) {
+            ALOGE("VEPlayer::%s no action found", __FUNCTION__);
+            return VE_INVALID_PARAMS;
+        }
+        
+        if (action == "open") {
+            std::string path;
+            if (!msg->findString("path", path)) {
+                ALOGE("VEPlayer::%s no path found", __FUNCTION__);
+                return VE_INVALID_PARAMS;
+            }
+            
+            // 获取reply token
+            std::shared_ptr<AReplyToken> replyToken;
+            msg->senderAwaitsResponse(replyToken);
+            
+            // 执行demux open操作
+            VEResult result = mDemux->open(path);
+            
+            // 发送回复
+            std::shared_ptr<AMessage> reply = std::make_shared<AMessage>();
+            reply->setInt32("result", result);
+            reply->postReply(replyToken);
+        }
+        
+        ALOGI("VEPlayer::%s exit", __FUNCTION__);
+        return VE_OK;
+    }
+
+    VEResult VEPlayer::onPrepareComponents() {
+        ALOGI("VEPlayer::%s enter", __FUNCTION__);
+        
+        // 获取媒体信息
+        mMediaInfo = mDemux->getFileInfo();
+        if (!mMediaInfo) {
+            ALOGE("VEPlayer::%s failed to get media info", __FUNCTION__);
+            return VE_UNKNOWN_ERROR;
+        }
+        
+        mAVSync = std::make_shared<VEAVsync>();
+        mRenderNotifyMsg = std::make_shared<AMessage>(kWhatRenderEvent, shared_from_this());
+
+        // 初始化音频组件
+        if(mMediaInfo->audio_stream_index != -1) {
+            mAudioDecodeLooper = std::make_shared<ALooper>();
+            mAudioDecodeLooper->setName("adec_thread");
+            mAudioDecodeLooper->start(false);
+
+            mAudioDecoder = std::make_shared<VEAudioDecoder>();
+            mAudioDecodeLooper->registerHandler(mAudioDecoder);
+            mAudioDecoder->prepare(mDemux);
+
+            mAudioOutputLooper = std::make_shared<ALooper>();
+            mAudioOutputLooper->setName("audio_render");
+            mAudioOutputLooper->start(false);
+
+            mAudioOutput = std::make_shared<VEAudioRender>(mRenderNotifyMsg, mAVSync);
+            mAudioOutputLooper->registerHandler(mAudioOutput);
+            VEBundle params;
+            params.set("samplerate",44100);
+            params.set("channel",2);
+            params.set("format",1);
+            params.set("decode",mAudioDecoder);
+            mAudioOutput->prepare(params);
+        }
+
+        // 初始化视频组件
+        if(mMediaInfo->video_stream_index != -1) {
+            mVideoDecodeLooper = std::make_shared<ALooper>();
+            mVideoDecodeLooper->setName("vdec_thread");
+            mVideoDecodeLooper->start(false);
+
+            mVideoDecoder = std::make_shared<VEVideoDecoder>();
+            mVideoDecodeLooper->registerHandler(mVideoDecoder);
+            mVideoDecoder->prepare(mDemux);
+
+            mVideoRenderLooper = std::make_shared<ALooper>();
+            mVideoRenderLooper->setName("video_render");
+            mVideoRenderLooper->start(false);
+            mVideoRender = std::make_shared<VEVideoDisplay>(mRenderNotifyMsg, mAVSync);
+            mVideoRenderLooper->registerHandler(mVideoRender);
+
+            VEBundle params;
+            params.set("surface",mWindow);
+            params.set("width",mViewWidth);
+            params.set("height",mViewHeight);
+            params.set("fps",mMediaInfo->fps);
+            params.set("decoder",mVideoDecoder);
+            mVideoRender->prepare(params);
+        }
+
+        // 所有组件准备完成，通知上层
+        if (onPreparedCallback) {
+            onPreparedCallback();
+        }
+        
+        ALOGI("VEPlayer::%s exit", __FUNCTION__);
+        return VE_OK;
     }
 }

--- a/lzplayer_core/src/main/cpp/core/VEPlayer.cpp
+++ b/lzplayer_core/src/main/cpp/core/VEPlayer.cpp
@@ -113,7 +113,6 @@ namespace VE {
             }
             case kWhatDemuxEvent: {
                 ALOGI("VEPlayer::onMessageReceived - kWhatDemuxEvent received");
-                onDemuxEvent(msg);
                 break;
             }
             case kWhatVideoDecEvent: {
@@ -214,26 +213,21 @@ namespace VE {
     VEResult VEPlayer::onPrepare(std::shared_ptr<AMessage> msg) {
         ALOGI("VEPlayer::%s enter", __FUNCTION__);
         
-        // 异步打开demux，完成后再初始化其他组件
-        std::shared_ptr<AMessage> demuxOpenMsg = std::make_shared<AMessage>(kWhatDemuxEvent, shared_from_this());
-        demuxOpenMsg->setString("action", "open");
-        demuxOpenMsg->setString("path", mPath);
-        
-        // 使用postAndAwaitResponse确保demux open完成后再继续
-        std::shared_ptr<AMessage> response;
-        demuxOpenMsg->postAndAwaitResponse(&response);
-        
-        int32_t demuxResult = VE_UNKNOWN_ERROR;
-        if (response && response->findInt32("result", &demuxResult) && demuxResult == VE_OK) {
-            // demux打开成功，继续初始化其他组件
-            onPrepareComponents();
-        } else {
-            // demux打开失败
+        // 直接调用demux的open方法，但确保它在demux线程中执行
+        VEResult demuxResult = mDemux->open(mPath);
+        if (demuxResult != VE_OK) {
             ALOGE("VEPlayer::%s demux open failed", __FUNCTION__);
             if (onErrorCallback) {
                 onErrorCallback(VE_PLAYER_ERROR_OPEN_DEMUX_FAILED, "demux open failed!!");
             }
             return VE_PLAYER_ERROR_OPEN_DEMUX_FAILED;
+        }
+        
+        // demux打开成功，继续初始化其他组件
+        VEResult result = onPrepareComponents();
+        if (result != VE_OK) {
+            ALOGE("VEPlayer::%s prepare components failed", __FUNCTION__);
+            return result;
         }
 
         ALOGI("VEPlayer::%s exit", __FUNCTION__);
@@ -452,39 +446,6 @@ namespace VE {
 
         ALOGI("VEPlayer::%s exit", __FUNCTION__);
         return 0;
-    }
-
-    VEResult VEPlayer::onDemuxEvent(std::shared_ptr<AMessage> msg) {
-        ALOGI("VEPlayer::%s enter", __FUNCTION__);
-        
-        std::string action;
-        if (!msg->findString("action", action)) {
-            ALOGE("VEPlayer::%s no action found", __FUNCTION__);
-            return VE_INVALID_PARAMS;
-        }
-        
-        if (action == "open") {
-            std::string path;
-            if (!msg->findString("path", path)) {
-                ALOGE("VEPlayer::%s no path found", __FUNCTION__);
-                return VE_INVALID_PARAMS;
-            }
-            
-            // 获取reply token
-            std::shared_ptr<AReplyToken> replyToken;
-            msg->senderAwaitsResponse(replyToken);
-            
-            // 执行demux open操作
-            VEResult result = mDemux->open(path);
-            
-            // 发送回复
-            std::shared_ptr<AMessage> reply = std::make_shared<AMessage>();
-            reply->setInt32("result", result);
-            reply->postReply(replyToken);
-        }
-        
-        ALOGI("VEPlayer::%s exit", __FUNCTION__);
-        return VE_OK;
     }
 
     VEResult VEPlayer::onPrepareComponents() {

--- a/lzplayer_core/src/main/cpp/core/VEPlayer.cpp
+++ b/lzplayer_core/src/main/cpp/core/VEPlayer.cpp
@@ -213,24 +213,61 @@ namespace VE {
     VEResult VEPlayer::onPrepare(std::shared_ptr<AMessage> msg) {
         ALOGI("VEPlayer::%s enter", __FUNCTION__);
         
-        // 直接调用demux的open方法，但确保它在demux线程中执行
-        VEResult demuxResult = mDemux->open(mPath);
-        if (demuxResult != VE_OK) {
-            ALOGE("VEPlayer::%s demux open failed", __FUNCTION__);
-            if (onErrorCallback) {
-                onErrorCallback(VE_PLAYER_ERROR_OPEN_DEMUX_FAILED, "demux open failed!!");
+        // 检查消息类型
+        int32_t isDemuxComplete = 0;
+        int32_t doDemuxOpen = 0;
+        msg->findInt32("demux_complete", &isDemuxComplete);
+        msg->findInt32("do_demux_open", &doDemuxOpen);
+        
+        if (isDemuxComplete == 1) {
+            // demux已完成，继续初始化其他组件
+            ALOGI("VEPlayer::%s received demux complete notification", __FUNCTION__);
+            VEResult result = onPrepareComponents();
+            if (result != VE_OK) {
+                ALOGE("VEPlayer::%s prepare components failed", __FUNCTION__);
+                return result;
             }
-            return VE_PLAYER_ERROR_OPEN_DEMUX_FAILED;
+            ALOGI("VEPlayer::%s exit", __FUNCTION__);
+            return VE_OK;
         }
         
-        // demux打开成功，继续初始化其他组件
-        VEResult result = onPrepareComponents();
-        if (result != VE_OK) {
-            ALOGE("VEPlayer::%s prepare components failed", __FUNCTION__);
-            return result;
+        if (doDemuxOpen == 1) {
+            // 执行demux open操作
+            ALOGI("VEPlayer::%s executing demux open", __FUNCTION__);
+            
+            std::shared_ptr<void> completionMsgObj;
+            msg->findObject("completion_msg", &completionMsgObj);
+            std::shared_ptr<AMessage> completionMsg = std::static_pointer_cast<AMessage>(completionMsgObj);
+            
+            VEResult demuxResult = mDemux->open(mPath);
+            if (demuxResult != VE_OK) {
+                ALOGE("VEPlayer::%s demux open failed", __FUNCTION__);
+                if (onErrorCallback) {
+                    onErrorCallback(VE_PLAYER_ERROR_OPEN_DEMUX_FAILED, "demux open failed!!");
+                }
+                return VE_PLAYER_ERROR_OPEN_DEMUX_FAILED;
+            }
+            
+            // demux open成功，发送完成通知
+            ALOGI("VEPlayer::%s demux open success, sending completion notification", __FUNCTION__);
+            completionMsg->post();
+            return VE_OK;
         }
-
-        ALOGI("VEPlayer::%s exit", __FUNCTION__);
+        
+        // 首次prepare调用，异步执行demux open
+        ALOGI("VEPlayer::%s starting async demux open", __FUNCTION__);
+        
+        // 创建一个回调消息，当demux完成时会发送此消息
+        std::shared_ptr<AMessage> completionMsg = std::make_shared<AMessage>(kWhatPrepare, shared_from_this());
+        completionMsg->setInt32("demux_complete", 1);
+        
+        // 异步调用demux open，在独立的任务中执行
+        std::shared_ptr<AMessage> openMsg = std::make_shared<AMessage>(kWhatPrepare, shared_from_this());
+        openMsg->setInt32("do_demux_open", 1);
+        openMsg->setObject("completion_msg", completionMsg);
+        openMsg->post();
+        
+        ALOGI("VEPlayer::%s exit (async)", __FUNCTION__);
         return VE_OK;
     }
 

--- a/lzplayer_core/src/main/cpp/core/VEPlayer.h
+++ b/lzplayer_core/src/main/cpp/core/VEPlayer.h
@@ -149,8 +149,6 @@ namespace VE {
         VEResult onSurfaceChanged(ANativeWindow *win,int viewWidth,int viewHeight);
         
         VEResult onPrepareComponents();
-        
-        VEResult onDemuxEvent(std::shared_ptr<AMessage> msg);
 
         pthread_mutex_t mMutex = PTHREAD_MUTEX_INITIALIZER;
         std::shared_ptr<VEDemux> mDemux = nullptr;

--- a/lzplayer_core/src/main/cpp/core/VEPlayer.h
+++ b/lzplayer_core/src/main/cpp/core/VEPlayer.h
@@ -147,6 +147,10 @@ namespace VE {
         VEResult onRelease(std::shared_ptr<AMessage> msg);
 
         VEResult onSurfaceChanged(ANativeWindow *win,int viewWidth,int viewHeight);
+        
+        VEResult onPrepareComponents();
+        
+        VEResult onDemuxEvent(std::shared_ptr<AMessage> msg);
 
         pthread_mutex_t mMutex = PTHREAD_MUTEX_INITIALIZER;
         std::shared_ptr<VEDemux> mDemux = nullptr;


### PR DESCRIPTION
Make demux `open` asynchronous in `VEPlayer::onPrepare` to ensure subsequent component preparation waits for demux to complete.

Previously, decoders and renderers would attempt to retrieve media information from demux before its `open` operation was guaranteed to be complete, leading to errors. This change ensures a proper sequential initialization by waiting for demux to finish before preparing other components.

---
<a href="https://cursor.com/background-agent?bcId=bc-3cc12f6a-20a4-4bf7-92aa-01ccbe9d7f91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3cc12f6a-20a4-4bf7-92aa-01ccbe9d7f91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

